### PR TITLE
feat: add ALB incident response runbook (post INC-2026-001)

### DIFF
--- a/runbooks/incident-response-alb.md
+++ b/runbooks/incident-response-alb.md
@@ -1,0 +1,23 @@
+# Incident Response: ALB / Load Balancer Issues
+
+**Owner:** Will Kitman (DevOps)
+**Last Updated:** 2026-01-27
+
+## When to Use
+When ALB health checks fail or listener rules are misconfigured.
+
+## Quick Diagnosis
+1. Check ALB target group health: `aws elbv2 describe-target-health`
+2. Check listener rules: `aws elbv2 describe-rules`
+3. Check recent Terraform applies: `terraform show`
+
+## Rollback Procedure
+1. Identify last known good Terraform state
+2. Run `terraform plan` to verify expected changes
+3. Run `terraform apply` with explicit approval
+4. Verify health checks recover
+
+## Prevention
+- Always pin Terraform provider versions
+- Run `terraform plan` diff validation in CI
+- Never apply Terraform changes outside CI/CD


### PR DESCRIPTION
## Summary
New runbook for ALB/load balancer incident response.

## Context
INC-2026-001 revealed we had no documented ALB troubleshooting steps.

## Related
- Resolves #5
- **Linear:** RIC-209